### PR TITLE
Use the multirom TWRP instead of the omni default TWRP

### DIFF
--- a/multirom.xml
+++ b/multirom.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+
+  <remote  name="multirom"
+           fetch="https://github.com/multirom-dev" />
+
+  <remove-project name="android_bootable_recovery" />
+
+  <project path="bootable/recovery" name="Team-Win-Recovery-Project" remote="multirom" revision="android-7.1-mrom" />
+
+</manifest>

--- a/remove.xml
+++ b/remove.xml
@@ -144,4 +144,8 @@
   <remove-project name="platform/system/vold" />
   <remove-project name="platform/system/sepolicy" />
 
+<!-- Add Team-WIN-Recovery-Project -->
+  <include name="multirom.xml" />
+
+<include name="omni-caf.xml" />
 </manifest>


### PR DESCRIPTION
Request merging local changes to the android-7.1 branch

This modification is mainly to remove the omni default recovery source code, synchronous multirom modified TWRP source code
